### PR TITLE
Terminate CI/CD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,7 @@
 name: Zephyr development container
 
 on:
-  schedule:
-    - cron: '24 8 * * *'
   push:
-    branches: [ main ]
-    tags: [ 'v*.*.*' ]
-  pull_request:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Part of the migration to https://github.com/embeddedcontainers is to stop automatically building images. Will still work if push to main but otherwise no new or updated images will be created.